### PR TITLE
Use system dependencies in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,18 @@ project(test_includes)
 #include_directories( ${Boost_INCLUDE_DIRS} )
 
 find_package(Boost COMPONENTS system filesystem REQUIRED)
-find_package(Threads)
+find_package(Threads REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
-include_directories( ${Boost_INCLUDE_DIRS} )
-include_directories(include)
+include_directories( ${Boost_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIR}
+  ${yaml-cpp_INCLUDE_DIR}
+  include)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-g -Wall -I /usr/local/include/eigen3/")
+#set(CMAKE_CXX_FLAGS "-g -Wall -I /usr/local/include/eigen3/")
 add_subdirectory(include)
 
 #link_directories(libraries)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,38 @@
 # multiagent_learning
+
 Top level project files for multiagent learning.
 
-Dependencies:
-  - boost
-  - eigen3
-  - yaml-cpp (https://github.com/jbeder/yaml-cpp)
-  - include (https://github.com/JenJenChung/include)
+## Installation ##
 
-From the multiagent_learning directory:
+### Linux ###
 
+Install system dependencies:
 ```
+sudo apt install libboost-dev libeigen3-dev libyaml-cpp-dev
+```
+
+In the working folder of your choice, clone the project code:
+```
+git clone https://github.com/JenJenChung/multiagent_learning.git
+```
+
+Clone internal dependencies:
+```
+cd multiagent_learning
 git clone https://github.com/JenJenChung/include.git
+```
 
+Build the code:
+```
 cd build
-
 cmake ..
-
 make
 ```
+
+## Running preconfigured projects
+
+Run the project configured by `config.yaml` using six threads:
+```
+./testWarehouse -c ./config.yaml -t 6
+```
+Cosult the documentation for details about configuration file options.


### PR DESCRIPTION
Simplify installation procedure by relying on system dependencies installed through `apt`.